### PR TITLE
Custom delimiters

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -6,19 +6,8 @@ import (
 	"github.com/mat2cc/redis_tui/tui"
 )
 
-type Options struct {
-	address         string
-	username        string
-	password        string
-	db              int
-	scanSize        int64
-	prettyPrintJson bool
-	includeTypes    bool
-}
-
 func Run() {
 	addressPtr := flag.String("address", "localhost:6379", "Redis server address")
-
 	usernamePtr := flag.String("username", "", "Redis username (optional)")
 	passwordPtr := flag.String("password", "", "Redis password (optional)")
 	dbPtr := flag.Int("db", 0, "Redis db (default 0)")
@@ -26,16 +15,22 @@ func Run() {
 	scanSize := flag.Int64("scan-size", 1000, "Number of keys scanned at a time")
 	prettyPrintJson := flag.Bool("pp-json", true, "Pretty print JSON values")
 	includeTypes := flag.Bool("include-types", true, "Include type values when querying keys. This includes a pipeline of batched TYPE commands for each key scanned, which may impact performace.")
+	delimiter := flag.String("delimiter", ":", "Delimiter for key names.")
 
 	flag.Parse()
 
-	tui.RunTUI(tui.Options{
-		Address:         *addressPtr,
-		Username:        *usernamePtr,
-		Password:        *passwordPtr,
-		DB:              *dbPtr,
-		ScanSize:        *scanSize,
-		PrettyPrintJson: *prettyPrintJson,
-		IncludeTypes:    *includeTypes,
-	})
+	tui.RunTUI(
+		tui.RedisOptions{
+			Address:  *addressPtr,
+			Username: *usernamePtr,
+			Password: *passwordPtr,
+			DB:       *dbPtr,
+		},
+		tui.ModelOptions{
+			ScanSize:        *scanSize,
+			PrettyPrintJson: *prettyPrintJson,
+			IncludeTypes:    *includeTypes,
+			Delimiter:       *delimiter,
+		},
+	)
 }

--- a/tui/node.go
+++ b/tui/node.go
@@ -33,14 +33,14 @@ func (tb *type_builder) add_type(node *Node, redis_type string) {
 	tb.pipe.Type(ctx, node.FullKey)
 }
 
-func (n *Node) GenNodes(keys []string, client *redis.Client, search string, include_types bool) {
+func (n *Node) GenNodes(keys []string, client *redis.Client, search string, opts ModelOptions) {
 	tb := new_type_builder(client)
 	for _, key := range keys {
-		split := strings.Split(key, ":")
+		split := strings.Split(key, opts.Delimiter)
 		n.AddChild(split, key, client, search, tb)
 	}
 
-	if include_types {
+	if opts.IncludeTypes {
 		cmds, err := tb.pipe.Exec(ctx)
 		if err != nil {
 			log.Fatal(err)

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -11,14 +11,11 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-type Options struct {
+type RedisOptions struct {
 	Address         string
 	Username        string
 	Password        string
 	DB              int
-	ScanSize        int64
-	PrettyPrintJson bool
-	IncludeTypes    bool
 }
 
 func CreateRedisClient(conn string, username string, password string, db int) (*redis.Client, error) {
@@ -40,12 +37,12 @@ func CreateRedisClient(conn string, username string, password string, db int) (*
 	return redis, nil
 }
 
-func RunTUI(opts Options) {
+func RunTUI(redis_opts RedisOptions, model_opts ModelOptions) {
 	client, err := CreateRedisClient(
-		opts.Address,
-		opts.Username,
-		opts.Password,
-		opts.DB,
+		redis_opts.Address,
+		redis_opts.Username,
+		redis_opts.Password,
+		redis_opts.DB,
 	)
 
 	if err != nil {
@@ -54,9 +51,7 @@ func RunTUI(opts Options) {
 	p := tea.NewProgram(
 		InitialModel(
 			client,
-			opts.ScanSize,
-			opts.PrettyPrintJson,
-			opts.IncludeTypes,
+            model_opts,
 		),
 		tea.WithAltScreen(),
 	)


### PR DESCRIPTION
adding the ability to use any delimiter. The default is still `:` so there are no breaking changes. 

Also:
- added tests for other delimiters
- refactored cli arguments/options to reduce duplication